### PR TITLE
Release v13.1.0 beta2

### DIFF
--- a/App/AppInfo/Launcher/ShareXPortable.ini
+++ b/App/AppInfo/Launcher/ShareXPortable.ini
@@ -5,3 +5,33 @@ SupportsUNC=yes
 
 [Activate]
 Registry=false
+
+[FileWrite1]
+Type=ConfigWrite
+File=%PAL:DataDir%\ApplicationConfig.json
+Entry='        "CLIPath": '
+Value='"Tools\\ffmpeg.exe",'
+
+[FileWrite2]
+Type=ConfigWrite
+File=%PAL:DataDir%\HotkeysConfig.json
+Entry='            "CLIPath": '
+Value='"Tools\\ffmpeg.exe",'
+
+[FileWrite3]
+Type=Replace
+File=%PAL:DataDir%\ApplicationConfig.json
+Find=%PAL:LastDrive%%PAL:LastPackagePartialDir:DoubleBackslash%\\Data
+Replace=%PAL:Drive%%PAL:PackagePartialDir:DoubleBackslash%\\Data
+
+[FileWrite4]
+Type=Replace
+File=%PAL:DataDir%\HotkeysConfig.json
+Find=%PAL:LastDrive%%PAL:LastPackagePartialDir:DoubleBackslash%\\Data
+Replace=%PAL:Drive%%PAL:PackagePartialDir:DoubleBackslash%\\Data
+
+[FileWrite5]
+Type=Replace
+File=%PAL:DataDir%\History.json
+Find=%PAL:LastDrive%%PAL:LastPackagePartialDir:DoubleBackslash%\\Data
+Replace=%PAL:Drive%%PAL:PackagePartialDir:DoubleBackslash%\\Data

--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -19,7 +19,7 @@ CommercialUse=true
 
 [Version]
 PackageVersion=13.1.0.0
-DisplayVersion=13.1.0-beta1-uroesch
+DisplayVersion=13.1.0-beta2-uroesch
 
 [Control]
 Icons=1

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,9 +1,13 @@
 [Version]
 Package = 13.1.0.0
-Display = 13.1.0-beta1-uroesch
+Display = 13.1.0-beta2-uroesch
 
 [Archive]
 URL1         = https://github.com/ShareX/ShareX/releases/download/v13.1.0/ShareX-portable.zip
 Checksum1    = SHA256:FD99F81376CE7A1A307331ECEA04F7B21A07A647482DFA0709FCB0D277047D46
 TargetName1  = ShareX
 ExtractName1 = 
+URL2         = https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-4.2.2-win32-static.zip
+Checksum2    = SHA256:1F6ADFF50DB6CAD54FDAB15013C4C95CB6F83D7FE6D1167F3896CF4550573565
+TargetName2  = ShareX\Tools\ffmpeg.exe
+ExtractName2 = ffmpeg-4.2.2-win32-static\bin\ffmpeg.exe

--- a/Other/Update/Update.ps1
+++ b/Other/Update/Update.ps1
@@ -6,7 +6,7 @@
 # -----------------------------------------------------------------------------
 # Globals
 # -----------------------------------------------------------------------------
-$Version        = "0.0.17-alpha"
+$Version        = "0.0.18-alpha"
 $AppRoot        = $(Convert-Path "$PSScriptRoot\..\..")
 $AppDir         = "$AppRoot\App"
 $AppInfoDir     = "$AppDir\AppInfo"
@@ -282,6 +282,13 @@ Function Update-Release {
     Remove-Item -Path $Download.MoveTo() `
       -Force `
       -Recurse
+  }
+  # Create destination Directory if not exist
+  $MoveBaseDir = $Download.MoveTo() | Split-Path
+  Debug info $MoveBaseDir
+  If (!(Test-Path $MoveBaseDir)) {
+  Debug info "Create directory $MoveBaseDir prior to moving items"
+    New-Item -Path $MoveBaseDir -Type "directory" | Out-Null
   }
   Debug info `
     "Move release from $($Download.MoveFrom()) to $($Download.MoveTo())"


### PR DESCRIPTION
Summary:
  * Add `WriteFile` to Luancher.ini to make
    the file history of screenshots fully
    portable.
  * Add download for `ffmpeg.exe` and place
    it in the `Tools` subdirectory.
  * Make the `ffmpeg` path relative to the
    the `ShareX` directory.